### PR TITLE
Incorporate plugin hosting review feedback and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ unclassified:
 
 After saving the configuration, the plugin will attempt to log in and perform an initial sync. You can verify success by checking the Jenkins system log or by navigating to the main Credentials page after a few moments to see your Bitwarden items.
 
+### Troubleshooting and Diagnostics
+
+The plugin includes several actions in the **Manage Jenkins > Configure System > Bitwarden Credentials Provider > Advanced** section to help you diagnose and quickly configure the plugin without needing to check the system log.
+
+- **Check Version:** Verifies that the Bitwarden CLI is installed and executable by Jenkins.
+- **Download Latest:** Forces a fresh download of the latest official Bitwarden CLI. This is useful for updating the CLI to a newer version.
+- **Verify Session Status:** Performs a fast, read-only check to see if the plugin currently has an active, unlocked session with the Bitwarden CLI. This is the quickest way to confirm that the plugin is logged in and ready to serve credentials.
+- **Refresh Now:** Forces the plugin to invalidate its current session and credential list and start a new sync in the background. Use this if you've made changes in your Bitwarden vault and want them to appear immediately.
+
 ## Read-Only Credential Store
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin integrates with personal vaults and organizations within the Passwor
 
 This plugin uses the official Bitwarden CLI (`bw`) as its engine for all interactions with your vault. Its architecture is designed for performance, security, and resilience.
 
-1.  **Isolated Environment:** The plugin manages its own copy of the `bw` executable and maintains its own isolated data directory. This ensures it never interferes with a system-level Bitwarden CLI installation.
+1.  **Bitwarden CLI Management:** The plugin manages its own copy of the `bw` executable for `x86_64` systems. Other architectures require manual installation and providing the path to the executable (see Getting Started).
 2.  **Efficient Caching:** On startup or after being configured, the plugin performs an initial `bw sync`. It then caches only the non-secret **metadata** (names, IDs, types) in Jenkins.
 3.  **Persistence:** The metadata cache is persisted to a file on the Jenkins controller. This allows Jenkins to start up and serve credentials instantly.
 4.  **Background Refresh:** The local vault is automatically re-synced with the Bitwarden server via `bw sync` in the background based on the "Cache Duration" setting, keeping your credentials reasonably fresh without impacting performance from slow CLI operations.
@@ -45,6 +45,7 @@ You must first configure the plugin's global settings in **Manage Jenkins > Conf
 -   **Bitwarden API Key Credential:** Select a Jenkins "Username with password" credential that stores your Bitwarden service account's Client ID and Client Secret.
 -   **Bitwarden Master Password Credential:** Select a Jenkins "Secret text" credential that stores your service account's Master Password.
 -   **Cache Duration:** Sets how often the plugin will sync with the Bitwarden server in the background.
+-   **Bitwarden CLI Executable Path: (Optional)** Provide the absolute path to a manually installed bw executable. This is required for Jenkins controllers running on CPU architectures for which there is no direct `bw` CLI download (e.g., `ARM`/`aarch64`).
 
 > [!IMPORTANT]
 > **Service Account Recommended**
@@ -85,6 +86,9 @@ unclassified:
     apiCredentialId: "bitwarden-api-key"
     # The Jenkins credential ID for your Bitwarden Master Password.
     masterPasswordCredentialId: "bitwarden-master-password"
+    # (Optional) The absolute path to a manually installed `bw` executable.
+    # Required for non-x86_64 architectures like ARM/aarch64.
+    cliExecutablePath: "/usr/local/bin/bw"
     # How often the plugin automatically syncs with the Bitwarden server (in minutes).
     cacheDuration: 10
     # Comma-separated list of suffixes for Secure Notes names to be treated as File Credentials.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > [!NOTE]
 > This is a third-party plugin and is not affiliated with, sponsored, or endorsed by Bitwarden, Inc.
 
-[![GitHub release](https://img.shields.io/github/release/mwdle/bitwarden-credentials-provider-plugin.svg?label=release)](https://github.com/mwdle/bitwarden-credentials-provider-plugin/releases/latest)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/bitwarden-credentials-provider-plugin.svg?label=release)](https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/bitwarden-credentials-provider.svg?color=blue)](https://plugins.jenkins.io/bitwarden-credentials-provider)
 
 The **Bitwarden Credentials Provider** is a [Jenkins](https://jenkins.io) plugin that dynamically exposes items from a **Bitwarden Password Manager** vault (including self-hosted [Vaultwarden](https://github.com/dani-garcia/vaultwarden)) as native Jenkins credentials. It allows pipeline authors to access any secret on the fly, without requiring an administrator to manually create or sync credentials in the Jenkins UI.
 
@@ -24,9 +25,10 @@ This plugin uses the official Bitwarden CLI (`bw`) as its engine for all interac
 
 1.  **Isolated Environment:** The plugin manages its own copy of the `bw` executable and maintains its own isolated data directory. This ensures it never interferes with a system-level Bitwarden CLI installation.
 2.  **Efficient Caching:** On startup or after being configured, the plugin performs an initial `bw sync`. It then caches only the non-secret **metadata** (names, IDs, types) in Jenkins.
-3.  **Persistence and Offline Access:** The metadata cache is persisted to a file on the Jenkins controller. This allows Jenkins to start up and serve credentials instantly, even if the Bitwarden server is unreachable or the controller is offline.
+3.  **Persistence:** The metadata cache is persisted to a file on the Jenkins controller. This allows Jenkins to start up and serve credentials instantly.
 4.  **Background Refresh:** The local vault is automatically re-synced with the Bitwarden server via `bw sync` in the background based on the "Cache Duration" setting, keeping your credentials reasonably fresh without impacting performance from slow CLI operations.
 5.  **Live, On-Demand Secret Fetching:** Your actual secrets (passwords, keys, etc.) are **never** cached by Jenkins. They are fetched "live" from the CLI's secure, local database at the exact moment a build needs to use them.
+6.  **Offline Access:** The Bitwarden CLI's local vault ensures that the plugin will continue functioning even if the Bitwarden server is unreachable or the controller is offline.
 
 > [!WARNING]
 > **Performance Consideration**
@@ -145,12 +147,12 @@ To avoid fetching secrets by their Bitwarden UUID, the solution is simple: *Alwa
 
 The plugin automatically converts Bitwarden items into the following Jenkins credential types.
 
-| Bitwarden Item Type | Jenkins Credential Type               | Notes                                                                   |
-|---------------------|---------------------------------------|-------------------------------------------------------------------------|
-| Login               | `StandardUsernamePasswordCredentials` |                                                                         |
-| Secure Note         | `StringCredentials`                   | The default for any secure note.                                        |
-| Secure Note         | `FileCredentials`                     | If the note's name ends with a user-configured suffix (e.g., `.env`).   |
-| SSH Key             | `SSHUserPrivateKey`                   | The username is parsed from the public key's comment field.             |
+| Bitwarden Item Type | Jenkins Credential Type               | Notes                                                                                                                         |
+|---------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Login               | `StandardUsernamePasswordCredentials` | The login item must contain a username or a password. If a field is missing, it will be treated as an empty string.           |
+| Secure Note         | `StringCredentials`                   | The default for any secure note. The Bitwarden Secure Note character limit applies here.                                      |
+| Secure Note         | `FileCredentials`                     | If the note's name ends with a user-configured suffix (e.g., `.env`). The Bitwarden Secure Note character limit applies here. |
+| SSH Key             | `SSHUserPrivateKey`                   | The username is parsed from the public key's comment field.                                                                   |
 
 ## License
 
@@ -162,7 +164,7 @@ This plugin is maintained by a single developer. While every effort is made to t
 
 **Found a Bug?**
 
-If you encounter any issues, please help improve the plugin by opening an issue on the [GitHub Issues](https://github.com/mwdle/bitwarden-credentials-provider-plugin/issues) page.
+If you encounter any issues, please help improve the plugin by opening an issue on the [GitHub Issues](https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/issues) page.
 
 **Want to Add a Feature or Fix?**
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>

--- a/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
+++ b/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
@@ -240,7 +240,8 @@ public class BitwardenConfig extends GlobalConfiguration {
     @POST
     public ListBoxModel doFillApiCredentialIdItems(
             @AncestorInPath Jenkins context, @QueryParameter String apiCredentialId) {
-        context.checkPermission(Jenkins.ADMINISTER);
+        if (!context.hasPermission(Jenkins.MANAGE))
+            return new StandardListBoxModel().includeCurrentValue(apiCredentialId);
         return new StandardListBoxModel()
                 .includeEmptyValue()
                 .includeMatchingAs(
@@ -264,7 +265,8 @@ public class BitwardenConfig extends GlobalConfiguration {
     @POST
     public ListBoxModel doFillMasterPasswordCredentialIdItems(
             @AncestorInPath Jenkins context, @QueryParameter String masterPasswordCredentialId) {
-        context.checkPermission(Jenkins.ADMINISTER);
+        if (!context.hasPermission(Jenkins.MANAGE))
+            return new StandardListBoxModel().includeCurrentValue(masterPasswordCredentialId);
         return new StandardListBoxModel()
                 .includeEmptyValue()
                 .includeMatchingAs(
@@ -287,7 +289,7 @@ public class BitwardenConfig extends GlobalConfiguration {
      */
     @POST
     public FormValidation doRefreshCache() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         try {
             LOGGER.info("Manual cache refresh triggered by administrator.");
             BitwardenSessionManager.getInstance().invalidateSessionToken();
@@ -308,7 +310,7 @@ public class BitwardenConfig extends GlobalConfiguration {
      */
     @POST
     public FormValidation doCheckCliVersion() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         try {
             String currentVersion = BitwardenCLI.version();
             return FormValidation.ok(Messages.validation_cliVersion(currentVersion));
@@ -327,7 +329,7 @@ public class BitwardenConfig extends GlobalConfiguration {
      */
     @POST
     public FormValidation doForceUpdateCli() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         try {
             LOGGER.info("Manual Bitwarden CLI update triggered by administrator.");
             BitwardenCLIManager.getInstance().downloadLatestExecutable();

--- a/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
+++ b/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
@@ -57,6 +57,8 @@ public class BitwardenConfig extends GlobalConfiguration {
     private String apiCredentialId;
     /** The Jenkins credential ID for the Bitwarden Master Password. */
     private String masterPasswordCredentialId;
+    /** The absolute path to a manually installed Bitwarden CLI executable. */
+    private String cliExecutablePath;
     /** The cache duration in minutes for the list of item metadata. */
     private int cacheDuration = 5; // Default to 5 minutes
     /** A comma-separated list of suffixes to identify FileCredentials. */
@@ -107,6 +109,10 @@ public class BitwardenConfig extends GlobalConfiguration {
         return masterPasswordCredentialId;
     }
 
+    public String getCliExecutablePath() {
+        return cliExecutablePath;
+    }
+
     public int getCacheDuration() {
         return cacheDuration;
     }
@@ -131,6 +137,11 @@ public class BitwardenConfig extends GlobalConfiguration {
     }
 
     @DataBoundSetter
+    public void setCliExecutablePath(String cliExecutablePath) {
+        this.cliExecutablePath = cliExecutablePath;
+    }
+
+    @DataBoundSetter
     public void setCacheDuration(int cacheDuration) {
         this.cacheDuration = (cacheDuration > 0) ? cacheDuration : 5;
     }
@@ -150,6 +161,7 @@ public class BitwardenConfig extends GlobalConfiguration {
         snapshot.serverUrl = this.serverUrl;
         snapshot.apiCredentialId = this.apiCredentialId;
         snapshot.masterPasswordCredentialId = this.masterPasswordCredentialId;
+        snapshot.cliExecutablePath = this.cliExecutablePath;
         return snapshot;
     }
 
@@ -196,7 +208,8 @@ public class BitwardenConfig extends GlobalConfiguration {
         boolean configChanged = loadedConfig == null
                 || !Objects.equals(this.serverUrl, loadedConfig.serverUrl)
                 || !Objects.equals(this.apiCredentialId, loadedConfig.apiCredentialId)
-                || !Objects.equals(this.masterPasswordCredentialId, loadedConfig.masterPasswordCredentialId);
+                || !Objects.equals(this.masterPasswordCredentialId, loadedConfig.masterPasswordCredentialId)
+                || !Objects.equals(this.cliExecutablePath, loadedConfig.cliExecutablePath);
 
         if (isConfigured() && configChanged) {
             LOGGER.info("Bitwarden configuration has changed, triggering background re-authentication and sync.");
@@ -330,6 +343,10 @@ public class BitwardenConfig extends GlobalConfiguration {
     @POST
     public FormValidation doForceUpdateCli() {
         Jenkins.get().checkPermission(Jenkins.MANAGE);
+        String userPath = getCliExecutablePath();
+        if (userPath != null && !userPath.trim().isEmpty()) {
+            return FormValidation.warning(Messages.validation_cliUpdateManual());
+        }
         try {
             LOGGER.info("Manual Bitwarden CLI update triggered by administrator.");
             BitwardenCLIManager.getInstance().downloadLatestExecutable();

--- a/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
+++ b/src/main/java/com/mwdle/bitwarden/BitwardenConfig.java
@@ -357,4 +357,27 @@ public class BitwardenConfig extends GlobalConfiguration {
             return FormValidation.error(Messages.validation_cliUpdateError(e.getMessage()));
         }
     }
+
+    /**
+     * An action method for the "Verify Session" button in the UI.
+     * <p>
+     * This method is called by Stapler.
+     * It performs a fast, read-only check to see if the {@link com.mwdle.bitwarden.cli.BitwardenSessionManager}
+     * currently holds a valid, unlocked session token.
+     *
+     * @return A {@link FormValidation} object indicating if the current session is active or not.
+     */
+    @POST
+    public FormValidation doVerifySession() {
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
+        if (!isConfigured()) {
+            return FormValidation.warning(Messages.validation_sessionNotConfigured());
+        }
+        boolean isValid = BitwardenSessionManager.getInstance().isSessionValid();
+        if (isValid) {
+            return FormValidation.ok(Messages.validation_sessionOk());
+        } else {
+            return FormValidation.warning(Messages.validation_sessionNotFound());
+        }
+    }
 }

--- a/src/main/java/com/mwdle/bitwarden/PluginDirectoryProvider.java
+++ b/src/main/java/com/mwdle/bitwarden/PluginDirectoryProvider.java
@@ -1,6 +1,9 @@
 package com.mwdle.bitwarden;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
@@ -44,14 +47,14 @@ public final class PluginDirectoryProvider {
                 return pluginDirectory;
             }
             File dir = new File(Jenkins.get().getRootDir(), PLUGIN_DIR_NAME);
-            if (!dir.exists()) {
-                if (!dir.mkdirs()) {
-                    String errorMessage = "Could not create plugin directory: " + dir.getAbsolutePath()
-                            + "\nDoes Jenkins have proper file permissions?";
-                    throw new RuntimeException(errorMessage);
-                } else {
-                    LOGGER.fine("Created plugin data directory: " + dir.getAbsolutePath());
-                }
+            try {
+                Files.createDirectories(dir.toPath());
+                LOGGER.fine("Plugin data directory is ready: " + dir.getAbsolutePath());
+            } catch (IOException e) {
+                String errorMessage = "Could not create plugin directory: " + dir.getAbsolutePath()
+                        + "\nDoes Jenkins have proper file permissions?";
+                LOGGER.log(Level.SEVERE, errorMessage, e);
+                throw new RuntimeException(errorMessage, e);
             }
             pluginDirectory = dir;
             return dir;

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -144,7 +144,7 @@ public final class BitwardenCLIManager {
      */
     @POST
     public boolean downloadLatestExecutable() {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         synchronized (provisionLock) {
             LOGGER.info("Downloading and provisioning the latest Bitwarden CLI executable...");
             try {

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -1,7 +1,6 @@
 package com.mwdle.bitwarden.cli;
 
 import com.mwdle.bitwarden.PluginDirectoryProvider;
-import hudson.Extension;
 import hudson.ProxyConfiguration;
 import java.io.File;
 import java.io.IOException;
@@ -18,8 +17,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.verb.POST;
 
 /**
  * A thread-safe singleton that manages the lifecycle of the Bitwarden CLI executable.
@@ -28,20 +25,25 @@ import org.kohsuke.stapler.verb.POST;
  * extraction of the executable, and provides a reliable, cached path for other components to use.
  * It ensures the CLI is always available when needed, attempting to download it if it's missing.
  */
-@Extension
 public final class BitwardenCLIManager {
 
+    private static final BitwardenCLIManager INSTANCE = new BitwardenCLIManager();
     private static final Logger LOGGER = Logger.getLogger(BitwardenCLIManager.class.getName());
     private volatile String executablePath;
     private final transient Object provisionLock = new Object();
 
     /**
-     * Provides global access to the single instance of this manager, as managed by Jenkins.
+     * A private constructor to prevent instantiation of this utility class.
+     */
+    private BitwardenCLIManager() {}
+
+    /**
+     * Provides global access to the single instance of this manager.
      *
      * @return The singleton instance of {@link BitwardenCLIManager}.
      */
     public static BitwardenCLIManager getInstance() {
-        return Jenkins.get().getExtensionList(BitwardenCLIManager.class).get(0);
+        return INSTANCE;
     }
 
     /**
@@ -154,9 +156,7 @@ public final class BitwardenCLIManager {
      *
      * @return {@code true} on success, {@code false} on failure.
      */
-    @POST
     public boolean downloadLatestExecutable() {
-        Jenkins.get().checkPermission(Jenkins.MANAGE);
         synchronized (provisionLock) {
             LOGGER.info("Downloading and provisioning the latest Bitwarden CLI executable...");
             try {

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -2,12 +2,15 @@ package com.mwdle.bitwarden.cli;
 
 import com.mwdle.bitwarden.PluginDirectoryProvider;
 import hudson.Extension;
+import hudson.ProxyConfiguration;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
@@ -89,18 +92,27 @@ public final class BitwardenCLIManager {
     }
 
     /**
-     * Downloads a zip archive from a URL, finds the {@code bw} executable within it,
-     * extracts it to the target file, and sets it as executable.
+     * Downloads a zip archive from a URL using Jenkins' proxy settings, finds the {@code bw} executable
+     * within it, extracts it to the target file, and sets it as executable.
      *
      * @param downloadUrl the URL of the zip archive to download.
      * @param targetFile  the destination file for the extracted executable.
      * @throws IOException if the download or extraction fails.
+     * @throws InterruptedException if the download is interrupted.
      */
-    private void downloadAndExtract(URL downloadUrl, File targetFile) throws IOException {
+    private void downloadAndExtract(URI downloadUrl, File targetFile) throws IOException, InterruptedException {
         LOGGER.fine(() -> "Downloading Bitwarden CLI from URL: " + downloadUrl);
         File bwCliZip = File.createTempFile("bw-cli", ".zip");
         try {
-            try (InputStream in = downloadUrl.openStream()) {
+            HttpClient client = ProxyConfiguration.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder(downloadUrl).build();
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            if (response.statusCode() != 200) {
+                throw new IOException("Failed to download file. Status code: " + response.statusCode());
+            }
+
+            try (InputStream in = response.body()) {
                 Files.copy(in, bwCliZip.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 LOGGER.fine("Downloaded zip to: " + bwCliZip.getAbsolutePath());
             }
@@ -153,12 +165,15 @@ public final class BitwardenCLIManager {
                 File pluginBinDir = getPluginBinDirectory();
                 File executableFile = new File(pluginBinDir, executableName);
 
-                downloadAndExtract(new URI(downloadUrl).toURL(), executableFile);
+                downloadAndExtract(new URI(downloadUrl), executableFile);
                 this.executablePath = executableFile.getAbsolutePath();
                 LOGGER.info("Successfully provisioned Bitwarden CLI at: " + this.executablePath);
                 return true;
-            } catch (IOException | URISyntaxException e) {
+            } catch (IOException | URISyntaxException | InterruptedException e) {
                 LOGGER.log(Level.SEVERE, "Failed to provision the Bitwarden executable.", e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
                 return false;
             }
         }

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -1,5 +1,6 @@
 package com.mwdle.bitwarden.cli;
 
+import com.mwdle.bitwarden.BitwardenConfig;
 import com.mwdle.bitwarden.PluginDirectoryProvider;
 import hudson.ProxyConfiguration;
 import java.io.File;
@@ -70,11 +71,27 @@ public final class BitwardenCLIManager {
     }
 
     /**
-     * Determines the correct download URL for the Bitwarden CLI based on the detected OS.
+     * Detects the current system architecture based on the {@code os.arch} system property and
+     * throws an exception there is no compatible Bitwarden executable available for download from the Bitwarden website.
+     *
+     * @throws UnsupportedOperationException if the architecture is not supported for automatic download.
+     */
+    private void checkSupportedArchitecture() {
+        String arch = System.getProperty("os.arch").toLowerCase();
+        if (!"amd64".equals(arch) && !"x86_64".equals(arch)) {
+            throw new UnsupportedOperationException(
+                    "Automatic download of Bitwarden CLI is not supported on this CPU architecture: " + arch
+                            + ". Please install the CLI manually and provide the path in the plugin configuration.");
+        }
+    }
+
+    /**
+     * Determines the correct download URL for the Bitwarden CLI based on the detected OS and architecture.
      *
      * @return A string containing the direct download URL.
      */
     private String getDownloadUrl() {
+        checkSupportedArchitecture();
         OS os = OS.detect();
         return switch (os) {
             case WINDOWS -> "https://bitwarden.com/download/?app=cli&platform=windows";
@@ -169,7 +186,7 @@ public final class BitwardenCLIManager {
                 this.executablePath = executableFile.getAbsolutePath();
                 LOGGER.info("Successfully provisioned Bitwarden CLI at: " + this.executablePath);
                 return true;
-            } catch (IOException | URISyntaxException | InterruptedException e) {
+            } catch (IOException | URISyntaxException | InterruptedException | UnsupportedOperationException e) {
                 LOGGER.log(Level.SEVERE, "Failed to provision the Bitwarden executable.", e);
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
@@ -211,13 +228,26 @@ public final class BitwardenCLIManager {
      * @throws IllegalStateException if the executable is not found and cannot be downloaded.
      */
     public String getExecutablePath() {
+        String userPath = BitwardenConfig.getInstance().getCliExecutablePath();
+        if (userPath != null && !userPath.trim().isEmpty()) {
+            File userCli = new File(userPath.trim());
+            if (userCli.exists() && userCli.canExecute()) {
+                LOGGER.fine(() -> "Using user-configured Bitwarden CLI path: " + userPath);
+                return userCli.getAbsolutePath();
+            } else {
+                LOGGER.warning("User-configured Bitwarden CLI path is invalid (does not exist or is not executable). "
+                        + "Falling back to automatic provisioning. Path: " + userPath);
+            }
+        }
         if (executablePath != null && new File(executablePath).exists()) {
             return executablePath;
         }
         if (provisionExecutable()) {
             return executablePath;
         } else {
-            throw new IllegalStateException("Bitwarden CLI is not installed and could not be downloaded.");
+            throw new IllegalStateException(
+                    "Bitwarden CLI is not installed and could not be downloaded automatically. "
+                            + "If on an unsupported architecture, please install it manually and set the path in the Jenkins configuration.");
         }
     }
 
@@ -228,18 +258,15 @@ public final class BitwardenCLIManager {
      * @throws RuntimeException if the directory cannot be created.
      */
     private File getPluginBinDirectory() {
-        LOGGER.fine("Getting plugin bin directory.");
         File pluginDir = PluginDirectoryProvider.getPluginDataDirectory();
         File binDir = new File(pluginDir, "bin");
-        if (!binDir.exists()) {
-            if (!binDir.mkdirs()) {
-                throw new RuntimeException("Could not create plugin bin directory: " + binDir.getAbsolutePath()
-                        + "\nDoes Jenkins have proper file permissions?");
-            } else {
-                LOGGER.fine("Created plugin bin directory: " + binDir.getAbsolutePath());
-            }
-        } else {
-            LOGGER.fine("Plugin bin directory already exists: " + binDir.getAbsolutePath());
+        try {
+            Files.createDirectories(binDir.toPath());
+            LOGGER.fine("Plugin bin directory is ready: " + binDir.getAbsolutePath());
+        } catch (IOException e) {
+            String errorMessage = "Could not create plugin bin directory: " + binDir.getAbsolutePath()
+                    + "\nDoes Jenkins have proper file permissions?";
+            throw new RuntimeException(errorMessage, e);
         }
         return binDir;
     }

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
@@ -58,14 +58,14 @@ public class BitwardenSessionManager {
      * @throws InterruptedException If the CLI command is interrupted.
      */
     public Secret getSessionToken() throws IOException, InterruptedException {
-        if (isTokenValid()) {
+        if (isSessionValid()) {
             LOGGER.fine("Cached Bitwarden session token is valid. Returning cached token.");
             return sessionToken;
         }
         LOGGER.fine("Token invalid or missing. Attempting to acquire lock to refresh token.");
         synchronized (lock) {
             // Double-check if another thread renewed the token while we were waiting for the lock.
-            if (isTokenValid()) {
+            if (isSessionValid()) {
                 LOGGER.fine("Another thread refreshed the token while waiting for lock. Returning refreshed token.");
                 return sessionToken;
             }
@@ -109,7 +109,7 @@ public class BitwardenSessionManager {
      *
      * @return {@code true} if the token is present and the vault status is {@code unlocked}.
      */
-    private boolean isTokenValid() {
+    public boolean isSessionValid() {
         if (this.sessionToken == null) {
             LOGGER.fine("Session token is null — not valid.");
             return false;

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
@@ -5,7 +5,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.mwdle.bitwarden.BitwardenConfig;
 import com.mwdle.bitwarden.BitwardenCredentialsProvider;
 import com.mwdle.bitwarden.model.BitwardenStatus;
-import hudson.Extension;
 import hudson.security.ACL;
 import hudson.util.Secret;
 import java.io.IOException;
@@ -21,11 +20,10 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
  * Bitwarden interactions are performed infrequently. It uses a high-performance, double-checked
  * locking pattern to provide concurrent access to the session token.
  */
-@Extension
 public class BitwardenSessionManager {
 
+    private static final BitwardenSessionManager INSTANCE = new BitwardenSessionManager();
     private static final Logger LOGGER = Logger.getLogger(BitwardenSessionManager.class.getName());
-
     private final Object lock = new Object();
     /**
      * The cached Bitwarden session token. This token is stored in memory and reused across
@@ -35,12 +33,17 @@ public class BitwardenSessionManager {
     private volatile Secret sessionToken;
 
     /**
-     * Provides global access to the single instance of this manager, as managed by Jenkins.
+     * A private constructor to prevent instantiation of this utility class.
+     */
+    private BitwardenSessionManager() {}
+
+    /**
+     * Provides global access to the single instance of this manager.
      *
      * @return The singleton instance of {@link BitwardenSessionManager}.
      */
     public static BitwardenSessionManager getInstance() {
-        return Jenkins.get().getExtensionList(BitwardenSessionManager.class).get(0);
+        return INSTANCE;
     }
 
     /**

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.jelly
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.jelly
@@ -20,28 +20,31 @@
             <f:entry title="${%field.cliExecutablePath}" field="cliExecutablePath">
                 <f:textbox />
             </f:entry>
+            <f:entry title="${%field.verifySession}" field="verifySession">
+                <f:helpArea />
+                <f:validateButton
+                        title="${%button.verifySession}"
+                        progress="${%button.checking}"
+                        method="verifySession" />
+            </f:entry>
             <f:entry title="${%field.cliManagement}" field="cliManagement">
-                <f:block>
-                    <f:helpArea />
-                    <f:validateButton
-                            title="${%button.checkVersion}"
-                            progress="${%button.checking}"
-                            method="checkCliVersion" />
-                    <f:validateButton
-                            title="${%button.downloadLatest}"
-                            progress="${%button.downloading}"
-                            method="forceUpdateCli" />
-                </f:block>
+                <f:helpArea />
+                <f:validateButton
+                        title="${%button.checkVersion}"
+                        progress="${%button.checking}"
+                        method="checkCliVersion" />
+                <f:validateButton
+                        title="${%button.downloadLatest}"
+                        progress="${%button.downloading}"
+                        method="forceUpdateCli" />
             </f:entry>
             <f:entry title="${%field.refreshCache}" field="refreshCache">
-                <f:block>
-                    <f:helpArea />
-                    <f:validateButton
-                            title="${%button.refreshNow}"
-                            progress="${%button.refreshing}"
-                            method="refreshCache"
-                            with="serverUrl,apiCredentialId,masterPasswordCredentialId" />
-                </f:block>
+                <f:helpArea />
+                <f:validateButton
+                        title="${%button.refreshNow}"
+                        progress="${%button.refreshing}"
+                        method="refreshCache"
+                        with="serverUrl,apiCredentialId,masterPasswordCredentialId" />
             </f:entry>
         </f:advanced>
     </f:section>

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.jelly
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.jelly
@@ -17,6 +17,9 @@
             <f:textbox default=".env" />
         </f:entry>
         <f:advanced title="${%section.advancedActions}">
+            <f:entry title="${%field.cliExecutablePath}" field="cliExecutablePath">
+                <f:textbox />
+            </f:entry>
             <f:entry title="${%field.cliManagement}" field="cliManagement">
                 <f:block>
                     <f:helpArea />

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.properties
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.properties
@@ -7,6 +7,7 @@ field.apiCredentialId=Bitwarden API Key Credential
 field.masterPasswordCredentialId=Bitwarden Master Password Credential
 field.cacheDuration=Item List Cache Duration (minutes)
 field.fileCredentialSuffixes=File Credential Suffixes
+field.cliExecutablePath=Bitwarden CLI Executable Path
 field.cliManagement=Bitwarden CLI Management
 field.refreshCache=Force Cache Refresh
 

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.properties
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/config.properties
@@ -8,13 +8,15 @@ field.masterPasswordCredentialId=Bitwarden Master Password Credential
 field.cacheDuration=Item List Cache Duration (minutes)
 field.fileCredentialSuffixes=File Credential Suffixes
 field.cliExecutablePath=Bitwarden CLI Executable Path
+field.verifySession=Verify Session Status
 field.cliManagement=Bitwarden CLI Management
 field.refreshCache=Force Cache Refresh
 
 # Section Labels
-section.advancedActions=Actions
+section.advancedActions=Advanced
 
 # Action Button Labels
+button.verifySession=Verify Session
 button.checkVersion=Check Version
 button.downloadLatest=Download Latest
 button.refreshNow=Refresh Now

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-cliExecutablePath.html
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-cliExecutablePath.html
@@ -1,0 +1,19 @@
+<div>
+    <p>
+        Optionally, provide the absolute path to a manually installed Bitwarden CLI (<code>bw</code>) executable.
+    </p>
+    <p>
+        This is useful for Jenkins controllers running on CPU architectures for which the plugin
+        cannot automatically download a compatible executable (e.g., ARM/aarch64).
+        In such cases, you must install the CLI on the Jenkins controller yourself
+        (e.g., via <code>npm</code>) and provide the full path to the <code>bw</code> executable here.
+    </p>
+    <p>
+        If this field is set correctly, the plugin will use this path and skip the automatic download process. The specified file
+        must exist and be executable by the Jenkins user.
+    </p>
+    <p>
+        You can easily test this option by setting the path, pressing the <b>Apply</b> button,
+        and then using the <b>Check Version</b>.
+    </p>
+</div>

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-cliExecutablePath.html
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-cliExecutablePath.html
@@ -14,6 +14,6 @@
     </p>
     <p>
         You can easily test this option by setting the path, pressing the <b>Apply</b> button,
-        and then using the <b>Check Version</b>.
+        and then pressing the <b>Check Version</b> button.
     </p>
 </div>

--- a/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-verifySession.html
+++ b/src/main/resources/com/mwdle/bitwarden/BitwardenConfig/help-verifySession.html
@@ -1,0 +1,13 @@
+<div>
+    <p>
+        This button is a diagnostic tool that answers one question: "Is the plugin currently logged in with an active session?" It is useful for understanding the plugin's state without needing to check the system log.
+    </p>
+    <ul>
+        <li>
+            <b>Success:</b> Indicates that the plugin logged in successfully and is ready to serve credentials.
+        </li>
+        <li>
+            <b>No Active Session:</b> This is normal for a brief period after a Jenkins restart, a configuration change, or if the provided credentials are incorrect.
+        </li>
+    </ul>
+</div>

--- a/src/main/resources/com/mwdle/bitwarden/Messages.properties
+++ b/src/main/resources/com/mwdle/bitwarden/Messages.properties
@@ -21,3 +21,6 @@ validation.cliUpdateOk=Successfully downloaded Bitwarden CLI. New version: {0}
 validation.cliUpdateManual=A manual CLI path is configured; automatic download is disabled.
 validation.cliUpdateError=Failed to update Bitwarden CLI: {0}
 validation.cliError=Failed to execute: {0}
+validation.sessionNotConfigured=Plugin is not configured.
+validation.sessionOk=Success! A valid session is active and the plugin is ready to serve credentials.
+validation.sessionNotFound=No active session found. This is normal after a restart or configuration change. Please try again in a moment.

--- a/src/main/resources/com/mwdle/bitwarden/Messages.properties
+++ b/src/main/resources/com/mwdle/bitwarden/Messages.properties
@@ -18,5 +18,6 @@ validation.refreshStarted=A background refresh has started.
 validation.refreshError=Failed to start cache refresh: {0}
 validation.cliVersion=Currently installed version: {0}
 validation.cliUpdateOk=Successfully downloaded Bitwarden CLI. New version: {0}
+validation.cliUpdateManual=A manual CLI path is configured; automatic download is disabled.
 validation.cliUpdateError=Failed to update Bitwarden CLI: {0}
 validation.cliError=Failed to execute: {0}

--- a/src/test/java/com/mwdle/bitwarden/BitwardenConfigTest.java
+++ b/src/test/java/com/mwdle/bitwarden/BitwardenConfigTest.java
@@ -316,4 +316,55 @@ class BitwardenConfigTest {
             assertTrue(result.getMessage().contains("Download failed"));
         }
     }
+
+    @Nested
+    @DisplayName("doVerifySession()")
+    class VerifySession {
+
+        @Test
+        @DisplayName("should return WARNING when not configured")
+        void shouldReturnWarningWhenNotConfigured() {
+            // GIVEN: The plugin is not configured
+            doReturn(false).when(config).isConfigured();
+
+            // WHEN
+            FormValidation result = config.doVerifySession();
+
+            // THEN
+            assertEquals(FormValidation.Kind.WARNING, result.kind);
+            assertTrue(result.getMessage().contains("Plugin is not configured"));
+            // Ensure no session check was even attempted
+            verify(sessionManagerMock, never()).isSessionValid();
+        }
+
+        @Test
+        @DisplayName("should return OK when session is valid")
+        void shouldReturnOkWhenSessionIsValid() {
+            // GIVEN: The plugin is configured and the session is valid
+            doReturn(true).when(config).isConfigured();
+            when(sessionManagerMock.isSessionValid()).thenReturn(true);
+
+            // WHEN
+            FormValidation result = config.doVerifySession();
+
+            // THEN
+            assertEquals(FormValidation.Kind.OK, result.kind);
+            assertTrue(result.getMessage().contains("Success! A valid session is active"));
+        }
+
+        @Test
+        @DisplayName("should return WARNING when session is not valid")
+        void shouldReturnWarningWhenSessionIsNotValid() {
+            // GIVEN: The plugin is configured but the session is not valid
+            doReturn(true).when(config).isConfigured();
+            when(sessionManagerMock.isSessionValid()).thenReturn(false);
+
+            // WHEN
+            FormValidation result = config.doVerifySession();
+
+            // THEN
+            assertEquals(FormValidation.Kind.WARNING, result.kind);
+            assertTrue(result.getMessage().contains("No active session found"));
+        }
+    }
 }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
@@ -3,6 +3,7 @@ package com.mwdle.bitwarden.cli;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.mwdle.bitwarden.BitwardenConfig;
 import com.mwdle.bitwarden.PluginDirectoryProvider;
 import hudson.ProxyConfiguration;
 import java.io.ByteArrayOutputStream;
@@ -22,7 +23,9 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Unit tests for the BitwardenCLIManager class.
@@ -39,12 +42,19 @@ class BitwardenCLIManagerTest {
 
     private MockedStatic<PluginDirectoryProvider> mockedPluginDir;
     private MockedStatic<ProxyConfiguration> mockedProxy;
+    private MockedStatic<BitwardenConfig> mockedConfig;
+
+    @Mock
+    private BitwardenConfig configMock;
+
     private BitwardenCLIManager manager;
     private String originalOsName;
+    private AutoCloseable closeable;
 
     @BeforeEach
     void setUp() throws Exception {
         originalOsName = System.getProperty("os.name");
+        closeable = MockitoAnnotations.openMocks(this);
 
         Constructor<BitwardenCLIManager> constructor = BitwardenCLIManager.class.getDeclaredConstructor();
         constructor.setAccessible(true);
@@ -55,21 +65,51 @@ class BitwardenCLIManagerTest {
         mockedPluginDir.when(PluginDirectoryProvider::getPluginDataDirectory).thenReturn(tempDir.toFile());
 
         mockedProxy = mockStatic(ProxyConfiguration.class);
+        mockedConfig = mockStatic(BitwardenConfig.class);
+        when(BitwardenConfig.getInstance()).thenReturn(configMock);
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws Exception {
         mockedPluginDir.close();
         mockedProxy.close();
+        mockedConfig.close();
+        closeable.close();
         System.setProperty("os.name", originalOsName);
     }
 
     @Nested
     @DisplayName("getExecutablePath() method")
     class GetExecutablePath {
+
+        @Test
+        @DisplayName("should use user-provided path when it is valid")
+        void shouldUseUserProvidedPathWhenValid() throws IOException {
+            File manualCli = tempDir.resolve("manual-bw").toFile();
+            assertTrue(manualCli.createNewFile());
+            assertTrue(manualCli.setExecutable(true));
+            when(configMock.getCliExecutablePath()).thenReturn(manualCli.getAbsolutePath());
+
+            String path = manager.getExecutablePath();
+
+            assertEquals(manualCli.getAbsolutePath(), path);
+            verify(manager, never()).provisionExecutable();
+        }
+
+        @Test
+        @DisplayName("should fall back to automatic provisioning when user-provided path is invalid")
+        void shouldFallBackWhenUserPathIsInvalid() {
+            when(configMock.getCliExecutablePath()).thenReturn("/invalid/path/to/bw");
+            doReturn(false).when(manager).provisionExecutable(); // Simulate provisioning failure for this test
+
+            assertThrows(IllegalStateException.class, () -> manager.getExecutablePath());
+            verify(manager, times(1)).provisionExecutable();
+        }
+
         @Test
         @DisplayName("should return cached path if executable exists")
         void shouldReturnCachedPathIfExecutableExists() throws Exception {
+            when(configMock.getCliExecutablePath()).thenReturn(null); // No manual path
             File executable = new File(tempDir.toFile(), "bw");
             assertTrue(executable.createNewFile(), "Test setup failed: could not create fake executable.");
 
@@ -86,6 +126,7 @@ class BitwardenCLIManagerTest {
         @Test
         @DisplayName("should provision executable if path is not cached")
         void shouldProvisionIfCacheIsEmpty() {
+            when(configMock.getCliExecutablePath()).thenReturn(null);
             doAnswer(invocation -> {
                         Field pathField = BitwardenCLIManager.class.getDeclaredField("executablePath");
                         pathField.setAccessible(true);
@@ -104,6 +145,7 @@ class BitwardenCLIManagerTest {
         @Test
         @DisplayName("should throw IllegalStateException if provisioning fails")
         void shouldThrowExceptionIfProvisioningFails() {
+            when(configMock.getCliExecutablePath()).thenReturn(null);
             doReturn(false).when(manager).provisionExecutable();
             assertThrows(IllegalStateException.class, () -> manager.getExecutablePath());
             verify(manager, times(1)).provisionExecutable();
@@ -132,6 +174,7 @@ class BitwardenCLIManagerTest {
         @DisplayName("should attempt to download if executable is missing")
         void shouldDownloadIfMissing() {
             System.setProperty("os.name", "Linux");
+            System.setProperty("os.arch", "amd64");
             doReturn(true).when(manager).downloadLatestExecutable();
 
             assertTrue(manager.provisionExecutable());

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.mwdle.bitwarden.PluginDirectoryProvider;
-import hudson.ExtensionList;
 import hudson.ProxyConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import jenkins.model.Jenkins;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
@@ -38,25 +37,19 @@ class BitwardenCLIManagerTest {
     @TempDir
     Path tempDir;
 
-    private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<PluginDirectoryProvider> mockedPluginDir;
     private MockedStatic<ProxyConfiguration> mockedProxy;
     private BitwardenCLIManager manager;
     private String originalOsName;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         originalOsName = System.getProperty("os.name");
-        manager = spy(new BitwardenCLIManager());
 
-        Jenkins jenkinsMock = mock(Jenkins.class);
-        @SuppressWarnings("unchecked")
-        ExtensionList<BitwardenCLIManager> extensionList = mock(ExtensionList.class);
-        when(extensionList.get(0)).thenReturn(manager);
-        when(jenkinsMock.getExtensionList(BitwardenCLIManager.class)).thenReturn(extensionList);
-        mockedJenkins = mockStatic(Jenkins.class);
-        mockedJenkins.when(Jenkins::get).thenReturn(jenkinsMock);
-        mockedJenkins.when(BitwardenCLIManager::getInstance).thenReturn(manager);
+        Constructor<BitwardenCLIManager> constructor = BitwardenCLIManager.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        BitwardenCLIManager instance = constructor.newInstance();
+        manager = spy(instance);
 
         mockedPluginDir = mockStatic(PluginDirectoryProvider.class);
         mockedPluginDir.when(PluginDirectoryProvider::getPluginDataDirectory).thenReturn(tempDir.toFile());
@@ -66,7 +59,6 @@ class BitwardenCLIManagerTest {
 
     @AfterEach
     void tearDown() {
-        mockedJenkins.close();
         mockedPluginDir.close();
         mockedProxy.close();
         System.setProperty("os.name", originalOsName);
@@ -128,7 +120,9 @@ class BitwardenCLIManagerTest {
             File binDir = new File(tempDir.toFile(), "bin");
             assertTrue(binDir.mkdirs(), "Test setup failed: could not create bin directory.");
             File executable = new File(binDir, "bw");
-            assertTrue(assertDoesNotThrow(executable::createNewFile), "Test setup failed: could not create fake executable.");
+            assertTrue(
+                    assertDoesNotThrow(executable::createNewFile),
+                    "Test setup failed: could not create fake executable.");
 
             assertTrue(manager.provisionExecutable());
             verify(manager, never()).downloadLatestExecutable();

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
@@ -5,12 +5,17 @@ import static org.mockito.Mockito.*;
 
 import com.mwdle.bitwarden.PluginDirectoryProvider;
 import hudson.ExtensionList;
+import hudson.ProxyConfiguration;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.ZipEntry;
@@ -35,6 +40,7 @@ class BitwardenCLIManagerTest {
 
     private MockedStatic<Jenkins> mockedJenkins;
     private MockedStatic<PluginDirectoryProvider> mockedPluginDir;
+    private MockedStatic<ProxyConfiguration> mockedProxy;
     private BitwardenCLIManager manager;
     private String originalOsName;
 
@@ -54,12 +60,15 @@ class BitwardenCLIManagerTest {
 
         mockedPluginDir = mockStatic(PluginDirectoryProvider.class);
         mockedPluginDir.when(PluginDirectoryProvider::getPluginDataDirectory).thenReturn(tempDir.toFile());
+
+        mockedProxy = mockStatic(ProxyConfiguration.class);
     }
 
     @AfterEach
     void tearDown() {
         mockedJenkins.close();
         mockedPluginDir.close();
+        mockedProxy.close();
         System.setProperty("os.name", originalOsName);
     }
 
@@ -70,7 +79,7 @@ class BitwardenCLIManagerTest {
         @DisplayName("should return cached path if executable exists")
         void shouldReturnCachedPathIfExecutableExists() throws Exception {
             File executable = new File(tempDir.toFile(), "bw");
-            executable.createNewFile();
+            assertTrue(executable.createNewFile(), "Test setup failed: could not create fake executable.");
 
             Field pathField = BitwardenCLIManager.class.getDeclaredField("executablePath");
             pathField.setAccessible(true);
@@ -117,7 +126,7 @@ class BitwardenCLIManagerTest {
         void shouldSucceedIfExecutableExists() {
             System.setProperty("os.name", "Linux");
             File binDir = new File(tempDir.toFile(), "bin");
-            binDir.mkdirs();
+            assertTrue(binDir.mkdirs(), "Test setup failed: could not create bin directory.");
             File executable = new File(binDir, "bw");
             assertTrue(executable.isFile() || assertDoesNotThrow(executable::createNewFile));
 
@@ -141,6 +150,7 @@ class BitwardenCLIManagerTest {
     class DownloadAndExtract {
         @Test
         @DisplayName("should extract correct file from zip and set executable")
+        @SuppressWarnings("unchecked")
         void shouldExtractCorrectFileFromZip() throws Exception {
             System.setProperty("os.name", "Linux");
             String executableName = "bw";
@@ -150,12 +160,24 @@ class BitwardenCLIManagerTest {
             byte[] zipBytes = createTestZipWithContent(
                     new ZipContent("some-other-file.txt", "hello".getBytes()),
                     new ZipContent(executableName, executableContent));
-            URL fakeUrl = createFakeUrlWithContent(zipBytes);
+            URI fakeUri = new URI("https://fake.bitwarden.com/download.zip");
+
+            HttpClient mockClient = mock(HttpClient.class);
+            @SuppressWarnings("unchecked")
+            HttpResponse<InputStream> mockResponse = mock(HttpResponse.class);
+
+            mockedProxy.when(ProxyConfiguration::newHttpClient).thenReturn(mockClient);
+
+            when(mockResponse.statusCode()).thenReturn(200);
+            when(mockResponse.body()).thenReturn(new java.io.ByteArrayInputStream(zipBytes));
+
+            when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenReturn(mockResponse);
 
             java.lang.reflect.Method method =
-                    BitwardenCLIManager.class.getDeclaredMethod("downloadAndExtract", URL.class, File.class);
+                    BitwardenCLIManager.class.getDeclaredMethod("downloadAndExtract", URI.class, File.class);
             method.setAccessible(true);
-            method.invoke(manager, fakeUrl, targetFile);
+            method.invoke(manager, fakeUri, targetFile);
 
             assertTrue(targetFile.exists(), "Target file should have been created");
             assertTrue(targetFile.canExecute(), "Target file should be executable");
@@ -164,17 +186,28 @@ class BitwardenCLIManagerTest {
 
         @Test
         @DisplayName("should throw IOException if executable not found in zip")
+        @SuppressWarnings("unchecked")
         void shouldThrowIfExecutableNotFound() throws Exception {
             System.setProperty("os.name", "Linux");
             byte[] zipBytes = createTestZipWithContent(new ZipContent("some-other-file.txt", "hello".getBytes()));
-            URL fakeUrl = createFakeUrlWithContent(zipBytes);
+            URI fakeUri = new URI("https://fake.bitwarden.com/download.zip");
             File targetFile = tempDir.resolve("bw_extracted").toFile();
+
+            HttpClient mockClient = mock(HttpClient.class);
+            @SuppressWarnings("unchecked")
+            HttpResponse<java.io.InputStream> mockResponse = mock(HttpResponse.class);
+            mockedProxy.when(ProxyConfiguration::newHttpClient).thenReturn(mockClient);
+            when(mockResponse.statusCode()).thenReturn(200);
+            when(mockResponse.body()).thenReturn(new java.io.ByteArrayInputStream(zipBytes));
+            when(mockClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenReturn(mockResponse);
+
             java.lang.reflect.Method method =
-                    BitwardenCLIManager.class.getDeclaredMethod("downloadAndExtract", URL.class, File.class);
+                    BitwardenCLIManager.class.getDeclaredMethod("downloadAndExtract", URI.class, File.class);
             method.setAccessible(true);
 
             Exception exception =
-                    assertThrows(InvocationTargetException.class, () -> method.invoke(manager, fakeUrl, targetFile));
+                    assertThrows(InvocationTargetException.class, () -> method.invoke(manager, fakeUri, targetFile));
 
             assertInstanceOf(IOException.class, exception.getCause());
             assertTrue(exception.getCause().getMessage().contains("Could not find 'bw' or 'bw.exe'"));
@@ -193,12 +226,6 @@ class BitwardenCLIManagerTest {
                 }
             }
             return baos.toByteArray();
-        }
-
-        private URL createFakeUrlWithContent(byte[] content) throws Exception {
-            URL urlMock = mock(URL.class);
-            when(urlMock.openStream()).thenReturn(new java.io.ByteArrayInputStream(content));
-            return urlMock;
         }
     }
 }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLIManagerTest.java
@@ -128,7 +128,7 @@ class BitwardenCLIManagerTest {
             File binDir = new File(tempDir.toFile(), "bin");
             assertTrue(binDir.mkdirs(), "Test setup failed: could not create bin directory.");
             File executable = new File(binDir, "bw");
-            assertTrue(executable.isFile() || assertDoesNotThrow(executable::createNewFile));
+            assertTrue(assertDoesNotThrow(executable::createNewFile), "Test setup failed: could not create fake executable.");
 
             assertTrue(manager.provisionExecutable());
             verify(manager, never()).downloadLatestExecutable();

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
@@ -12,6 +12,7 @@ import hudson.ExtensionList;
 import hudson.model.ItemGroup;
 import hudson.util.Secret;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +65,9 @@ class BitwardenSessionManagerTest {
         mockedJenkins.when(Jenkins::getAuthentication2).thenReturn(authenticationMock);
         when(BitwardenConfig.getInstance()).thenReturn(configMock);
 
-        manager = new BitwardenSessionManager();
+        Constructor<BitwardenSessionManager> constructor = BitwardenSessionManager.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        manager = constructor.newInstance();
 
         sessionTokenField = BitwardenSessionManager.class.getDeclaredField("sessionToken");
         sessionTokenField.setAccessible(true);


### PR DESCRIPTION
This PR addresses feedback from [the initial Jenkins plugin hosting](https://github.com/jenkins-infra/repository-permissions-updater/issues/4668) request and introduces several improvements to enhance stability, security, and user experience.

Review Feedback Addressed 
- Guava Dependency: Removed explicit Guava dependency from pom.xml, as it's provided by Jenkins core.
- Permissions: Lowered permission checks to `Jenkins.MANAGE` and updated credential dropdowns to gracefully handle users with read-only access.
- Proxy Support: Implemented `ProxyConfiguration` for downloading the Bitwarden CLI, ensuring compatibility with environments reliant on proxy.
- Directory Creation: Switched to `Files.createDirectories()` for a more robust, thread-safe method of creating plugin directories.
- Architecture Support: Added proper support for non-x86_64 architectures by allowing users to specify a manual CLI path and providing a clear error message if automatic download is not supported.
- Links & Annotations: Corrected the project URL to point to the jenkinsci organization.
- Removed a erroneous `@Extension` annotation from `BitwardenCLIManager`.

New Features & Improvements
- Verify Session Button: Added a safe, read-only "Verify Session Status" button to the configuration page. This provides administrators with a quick and easy way to check if the plugin has an active, unlocked session without needing to check logs or trigger a full refresh.